### PR TITLE
When attempting to find an allocation of items to members, it is poss…

### DIFF
--- a/pkg/v3.allocator/allocator.go
+++ b/pkg/v3.allocator/allocator.go
@@ -105,6 +105,11 @@ func (a *Allocator) Serve(ctx context.Context, client *clientv3.Client) error {
 					fn.init(as)
 					push_relabel.FindMaxFlow(&fn.source, &fn.sink)
 
+					if excessCapacity := fn.excessItemCapacity(); excessCapacity > 0 {
+						log.WithField("unattainable_replicas", excessCapacity).
+							Warn("not enough members to reach desired replication for all items")
+					}
+
 					// Extract desired max-flow Assignments for each Item.
 					desired = desired[:0]
 					for item := range as.items {

--- a/pkg/v3.allocator/flow_network.go
+++ b/pkg/v3.allocator/flow_network.go
@@ -234,3 +234,15 @@ func extractItemFlow(s *allocState, fn *flowNetwork, item int, out []Assignment)
 	})
 	return out
 }
+
+// Returns the excess capacity across all items in the flow network. This represents the number of replicas
+// that we are unable to assign to members in the current flow network. If the flow network is a max flow,
+// then it is impossible to meet the desired replication constraints for all our items, and we probably want
+// to create more members or adjust their allocation between zones.
+func (fn *flowNetwork) excessItemCapacity() int32 {
+	var excess int32 = 0
+	for _, arc := range fn.source.Arcs {
+		excess += arc.Capacity - arc.Flow
+	}
+	return excess
+}


### PR DESCRIPTION
…ible for us to fail to replicate each item the desired number of times

if there are too few members or if members are poorly distributed across zones. Log a warning in the case where there is no possible
allocation that meets our desired replication constraints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgraettinger/gazette/1)
<!-- Reviewable:end -->
