### PR TITLE
Change shard update error log to warning

### DIFF
--- a/consumer/shard.go
+++ b/consumer/shard.go
@@ -298,7 +298,7 @@ func updateStatusWithRetry(s *shard, status pc.ReplicaStatus) {
 			return
 		}
 		log.WithFields(log.Fields{"err": err, "attempt": attempt}).
-			Error("failed to advertise Etcd shard status (will retry)")
+			Warn("failed to advertise Etcd shard status (will retry)")
 	}
 }
 


### PR DESCRIPTION
Shard update failures happen with some regularity, and they get retried
automatically. This logs them at the warn level instead of error, to
clarify that it's likely not something that users need to investigate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgraettinger/gazette/3)
<!-- Reviewable:end -->
